### PR TITLE
fix luci.mk path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Rosy Theme
 LUCI_DEPENDS:=
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
兼容 luci-theme-* 安装在任意路径的情况

Refer: rosywrt/luci-theme-rosy#8

Refer: coolsnowwolf/lede@72e44c8