### PR TITLE
fix #58

### DIFF
--- a/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
+++ b/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
@@ -1217,7 +1217,7 @@ td > .ifacebadge,
 }
 
 .network-status-table .ifacebox-body > span {
-    flex: 10 10 auto;
+    flex: 10 10;
 }
 
 .network-status-table .ifacebox-body > div {


### PR DESCRIPTION
Fixed a bug in the overlap of the network part of the overview page under chrome
#
修复了chrome下总览页面网络部分盒子重叠的bug